### PR TITLE
Add --bare option to 'all' command.

### DIFF
--- a/lib/App/gh/Command/All.pm
+++ b/lib/App/gh/Command/All.pm
@@ -68,7 +68,8 @@ sub options { (
         "ssh" => "protocal_ssh",    # git@github.com:c9s/repo.git
         "http" => "protocal_http",  # http://github.com/c9s/repo.git
         "https" => "https",         # https://github.com/c9s/repo.git
-        "git|ro"   => "git"         # git://github.com/c9s/repo.git
+        "git|ro"   => "git",         # git://github.com/c9s/repo.git
+        "bare" => "bare",
     ) }
 
 
@@ -129,6 +130,7 @@ sub run {
 
             my $flags = qq();
             $flags .= qq{ -q } unless $self->{verbose};
+            $flags .= qq{ --bare } if $self->{bare};
 
             qx{ git pull $flags --rebase --all };
 
@@ -140,6 +142,7 @@ sub run {
 
             my $flags = qq();
             $flags .= qq{ -q } unless $self->{verbose};
+            $flags .= qq{ --bare } if $self->{bare};
 
             qx{ git clone $flags $uri };
         }


### PR DESCRIPTION
It is useful to mirror someone's github all repos.

```
$ cd git/+public # git-daemon's public directory.
$ gh all --bare tyru # mirror all repos. (git-daemon only accepts bare repos)
```
