### PR TITLE
List: default to user

### DIFF
--- a/lib/App/gh/Command/List.pm
+++ b/lib/App/gh/Command/List.pm
@@ -23,6 +23,7 @@ sub options {
 sub run {
     my ( $self, $acc ) = @_;
 
+    $acc ||= App::gh->config->github_id;
     $acc =~ s{/$}{};
 
 	# TODO: use api class.


### PR DESCRIPTION
When the list subcommand is called without a userid being passed,
we now use the user's github id.
