### PR TITLE
fix for https://github.com/c9s/App-gh/issues/21

### DIFF
--- a/lib/App/gh/Command/Drop.pm
+++ b/lib/App/gh/Command/Drop.pm
@@ -31,11 +31,10 @@ sub run {
     print "Deleting @{[ $gh_id ]}/@{[ $repo ]}\n";
 
     # repos/delete/:user/:repo
-    my $uri = sprintf( qq{repos/delete/%s/%s?login=%s&token=%s}, $gh_id , $repo, $gh_id , $gh_token );
-    my $ret = App::gh->api->request($uri);
+    my $uri = sprintf( qq{repos/delete/%s/%s}, $gh_id , $repo );
+    my $ret = App::gh->api->request(POST => $uri);
     my $delete_token = $ret->{delete_token};
-    $uri .= '&delete_token=' . $delete_token;
-    $ret = App::gh->api->request($uri);
+    $ret = App::gh->api->request(POST => $uri, delete_token => $delete_token);
     print $ret->{status} , "\n";
     return;
 }

--- a/lib/App/gh/Command/Pull.pm
+++ b/lib/App/gh/Command/Pull.pm
@@ -78,7 +78,7 @@ sub run {
         print "Available forks:\n";
 
         # XXX: refactor this ... XD
-        my $objs = App::gh->api->request(qq(repos/show/$userid/$repo/network));
+        my $objs = App::gh->api->request(GET => qq(repos/show/$userid/$repo/network));
         my $networks = $objs->{network};
         for my $net ( @$networks ) {
             print sprintf( "% 20s - watchers(%d) forks(%d)\n"


### PR DESCRIPTION
Latest App::gh (0.46) had a broken `gh info`/`gh import` due to
API->request only doing a POST without putting credentials in the proper
format.  Fix this by making API->request accept a GET or POST parameter
and act accordingly.

For POST requests, put login and token credentials along with other
payload in a multipart/form-data wrapper.  This is the behavior seen in
the curl POST examples of the API documentation at
http://develop.github.com/p/repo.html
