### PR TITLE
enable pull request list/show commands only when IO::Pager is available

### DIFF
--- a/lib/App/gh/Command/Pullreq/List.pm
+++ b/lib/App/gh/Command/Pullreq/List.pm
@@ -6,7 +6,6 @@ use App::gh::Utils;
 use File::stat;
 use File::Temp;
 use Text::Wrap;
-use IO::Pager;
 require App::gh::Git;
 
 
@@ -42,6 +41,11 @@ sub get_remote {
 
 sub run {
     my $self = shift;
+
+    eval {
+        require IO::Pager;
+    };
+    die 'Please install IO::Pager to enable this command' if $@;
 
     my $remote = $self->get_remote();
 

--- a/lib/App/gh/Command/Pullreq/Show.pm
+++ b/lib/App/gh/Command/Pullreq/Show.pm
@@ -6,7 +6,6 @@ use App::gh::Utils;
 use File::stat;
 use File::Temp;
 use Text::Wrap;
-use IO::Pager;
 require App::gh::Git;
 
 
@@ -52,6 +51,11 @@ sub run {
     my ($self, $number) = @_;
     return App::gh::Command->invoke('help', 'pullreq', 'show')
         unless defined $number;
+
+    eval {
+        require IO::Pager;
+    };
+    die 'Please install IO::Pager to enable this command' if $@;
 
     my $remote = $self->get_remote();
 


### PR DESCRIPTION
Hi there,

Thanks for App::gh, it's great!

I made this simple pull request so that it compiles/works in systems without IO::Pager installed.

An alternative fix would be to simply add it to Makefile.PL as "requires" instead of "recommends", but I figured there must have been a reason to do so, so instead I made it require the module just like it was in other pieces of the distribution.

Cheers!
