### PR TITLE
Handle https origin urls when listing networks

### DIFF
--- a/lib/App/gh/Command/Network.pm
+++ b/lib/App/gh/Command/Network.pm
@@ -32,8 +32,8 @@ sub get_networks {
     # git://github.com/miyagawa/Tatsumaki.git
     #   -or-
     # https://github.com/miyagawa/Tatsumaki.git
-    if ( $url && ( $url =~ m{git://github.com/(.*?)/(.*?).git}
-            || $url =~ m{git\@github.com:(.*?)/(.*?).git}
+    if ( $url && ( $url =~ m{git://github.com/(.*?)/(.*?)\.git}
+            || $url =~ m{git\@github.com:(.*?)/(.*?)\.git}
             || $url =~ m{https://github.com/(.*?)/(.*?)\.git} ) ) {
 
         my ( $acc, $repo ) = ( $1, $2 );


### PR DESCRIPTION
...as we don't get any useful info otherwise.

Also, this might not be an issue, but the second commit in this branch escapes
the . in .git in the network regexes, as well.
