### PR TITLE
Topic/pull fixups

### DIFF
--- a/lib/App/gh/Command.pm
+++ b/lib/App/gh/Command.pm
@@ -36,8 +36,8 @@ sub invoke {
 
 sub parse_remote_param {
     my $uri = shift;
-    if ( $uri =~ m{(?:git|https?)://github.com/(.*?)/(.*?).git}
-        || $uri =~ m{git\@github.com:(.*?)/(.*?).git} )
+    if ( $uri =~ m{(?:git|https?)://github.com/(.*?)/(.*?)\.git$}
+        || $uri =~ m{git\@github.com:(.*?)/(.*?)\.git$} )
     {
         return ( $1 , $2 )
             if( $1 && $2 );

--- a/lib/App/gh/Command/Pull.pm
+++ b/lib/App/gh/Command/Pull.pm
@@ -73,7 +73,7 @@ sub run {
 
 
         my $origin_url = qx( git remote -v | grep origin | grep fetch );
-        my ($userid,$repo) = ($origin_url =~ m{:(\w+)/(.*?)\.git});
+        my ($userid,$repo) = ($origin_url =~ m{:(\w+)/(.*?)\.git$});
 
         print "Available forks:\n";
 
@@ -95,7 +95,7 @@ sub run {
     $to_branch   ||= 'master';
 
     if( qx(git diff) ) {
-        die "Your repository is diryt\n";
+        die "Your repository is dirty!\n";
     }
 
     die "git config not found." if  ! -e ".git/config" ;


### PR DESCRIPTION
"gh pull" was botching the remote url for a pull, a la:

```
    [3] { ~/work/p5/dist-zilla-pluginbundle-git-checkfor }$ gh pull karenetheridge
        Adding remote [karenetheridge] for
        [git://github.com/karenetheridge/dist-zilla-pluginbundle.git]
        Fetching karenetheridge ...
          fatal: remote error:
        Repository not found.
        Done
```

This should address that, as well as allow fetch as an alias to pull.
