### PR TITLE
Parse 'git' command output

### DIFF
--- a/lib/App/gh/Config.pm
+++ b/lib/App/gh/Config.pm
@@ -18,7 +18,7 @@ sub parse {
     return $_parse_memoize{$file} if exists $_parse_memoize{$file};
 
     my %config;
-    for my $line (split "\n", qx(git config --list -f $file)) {
+    for my $line (split "\n", qx(git config --list -f '$file')) {
         # $line = foo.bar.baz=value
         if (my ($key, $value) = ($line =~ m/^([^=]+)=(.*)/)) {
             my $h = \%config;


### PR DESCRIPTION
Rewrote `App::gh::Config::parse()` to parse 'git' command output.

This results in:
- Support include.path in .gitconfig `[include] path = ~/.gitconfig.secret`
  - This feature was implemented in git 1.7.10
  - If user saved github token in `~/.gitconfig.secret` (like me), `gh` outputs an error about no github token.
- `git config --list` outputs easy-to-parse string. so the code is simple.

Notice:
- `App::gh::Config::parse()` uses memoization (not to invoke 'git' command frequently). so if you wrote the code modifying `~/.gitconfig` or `.git/config` after calling `App::gh::Config::parse()`, the function wil return wrong value.
  - If you don't like this, you can merge only [this commit](https://github.com/c9s/App-gh/commit/1220451c02f616242b883e4420c5261a74103cdc) using `git cherry-pick`.

This branch is based on 'master' branch.
Because 'develop' branch currently does not work.

```
$ gh recent
Use of uninitialized value $token in concatenation (.) or string at lib/App/gh/Command/Recent.pm line 31.
Died at lib/App/gh/Command/Recent.pm line 32.

$ gh list
Can't locate object method "api" via package "App::gh" at lib/App/gh/Command/List.pm line 30.
```
