### PR TITLE
removed Non-ASCII dash with ASCII dash to allow pod test to pass

### DIFF
--- a/lib/App/gh/Command/Pull.pm
+++ b/lib/App/gh/Command/Pull.pm
@@ -37,7 +37,7 @@ This will create a gugod-master branch:
 
 =head3 Github Steps:
 
-Step 1: Check out a new branch to test the changes — run this from your project directory
+Step 1: Check out a new branch to test the changes - run this from your project directory
 
     git checkout -b chocolateboy-optional_dep_and_warnings_fixes master
 


### PR DESCRIPTION
Which should resolve this test failure on install
# Failed test 'POD test for blib/lib/App/gh/Command/Pull.pm'
# at /Users/dsteinbrunner/perl5/perlbrew/perls/perl-5.18.1/lib/site_perl/5.18.1/Test/Pod.pm line 186.

Wide character in print at /Users/dsteinbrunner/perl5/perlbrew/perls/perl-5.18.1/lib/5.18.1/Test/Builder.pm line 1821.
# blib/lib/App/gh/Command/Pull.pm (40): Non-ASCII character seen before =encoding in '—'. Assuming UTF-8
# Looks like you failed 1 test of 33.

t/pod.t ....... 
Dubious, test returned 1 (wstat 256, 0x100)
